### PR TITLE
Fix stage shorthand from st to g

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -47,6 +47,6 @@ func init() {
 
 	listCmd.Flags().StringVarP(&milestone, "milestone", "m", "", "Milestone to filter KEPs by.")
 	listCmd.Flags().StringVarP(&sig, "sig", "s", "", "SIG to filter KEPs by.")
-	listCmd.Flags().StringVarP(&stage, "stage", "st", "", "Stage to filter KEPs by (alpha|beta|stable).")
+	listCmd.Flags().StringVarP(&stage, "stage", "g", "", "Stage to filter KEPs by (alpha|beta|stable).")
 	listCmd.Flags().BoolVarP(&tracked, "tracked", "t", false, "Filter for tracked KEPs only.")
 }


### PR DESCRIPTION
:wave:  Hi Xander,

Cool project. I took a peek around and ran into a problem while running `kept login`. Looks like for Cobra a shorthand flag cannot be more than one ASCII character. This is the response I got when running `kept login`.

```bash
panic: "st" shorthand is more than one ASCII character

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).AddFlag(0xc0001ba200, 0xc0001d4b40)
        /Users/thomaseckert/go/pkg/mod/github.com/spf13/pflag@v1.0.5/flag.go:864 +0x765
github.com/spf13/pflag.(*FlagSet).VarPF(0xc0001ba200, 0x1632470, 0x18e5210, 0x157ec6e, 0x5, 0x157dc84, 0x2, 0x15934c9, 0x2c, 0xc0001d4aa0)
        /Users/thomaseckert/go/pkg/mod/github.com/spf13/pflag@v1.0.5/flag.go:831 +0x10b
github.com/spf13/pflag.(*FlagSet).VarP(...)
        /Users/thomaseckert/go/pkg/mod/github.com/spf13/pflag@v1.0.5/flag.go:837
github.com/spf13/pflag.(*FlagSet).StringVarP(0xc0001ba200, 0x18e5210, 0x157ec6e, 0x5, 0x157dc84, 0x2, 0x0, 0x0, 0x15934c9, 0x2c)
        /Users/thomaseckert/go/pkg/mod/github.com/spf13/pflag@v1.0.5/string.go:42 +0xad
github.com/salaxander/kept/cmd.init.1()
        /Users/thomaseckert/go/src/github.com/t-eckert/kept/cmd/list.go:50 +0x1b8
exit status 2
```

I took a look into it and saw that the shorthand flag fails if it is more than a single ASCII character. So I changed it from `"st"` to `"g"`. I thought this made sense as the "g" sound in stage is very prominent and the "t" flag was already taken.
