### PR TITLE
Add kept check cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+OUTDIR ?= _output
+
+.PHONY: build-cli
+build-cli: $(OUTDIR)/kept-linux-$(GOARCH).sha256
+build-cli: $(OUTDIR)/kept-darwin-$(GOARCH).sha256
+
+.PHONY: install-cli
+install-cli:
+	go install -ldflags=$(LDFLAGS) -gcflags=$(GCFLAGS) ./main.go
+
+.PHONY: kept-linux-$(GOARCH)
+kept-linux-$(GOARCH): $(OUTDIR)/kept-linux-$(GOARCH)
+$(OUTDIR)/kept-linux-$(GOARCH): $(SOURCES)
+	CGO_ENABLED=0 GOARCH=$(GOARCH) GOOS=linux go build -ldflags=$(LDFLAGS) -gcflags=$(GCFLAGS) -o $@ main.go
+	upx $@
+
+$(OUTDIR)/kept-linux-$(GOARCH).sha256: $(SOURCES) $(OUTDIR)/kept-linux-$(GOARCH)
+	shasum -a 256 $(OUTDIR)/kept-linux-$(GOARCH) > $(OUTDIR)/kept-linux-$(GOARCH).sha256
+
+.PHONY: kept-darwin-$(GOARCH)
+kept-darwin-$(GOARCH): $(OUTDIR)/kept-darwin-$(GOARCH)
+$(OUTDIR)/kept-darwin-$(GOARCH): $(SOURCES)
+	CGO_ENABLED=0 GOARCH=$(GOARCH) GOOS=darwin go build -ldflags=$(LDFLAGS) -gcflags=$(GCFLAGS) -o $@ main.go
+
+$(OUTDIR)/kept-darwin-$(GOARCH).sha256: $(SOURCES) $(OUTDIR)/kept-darwin-$(GOARCH)
+	shasum -a 256 $(OUTDIR)/kept-darwin-$(GOARCH) > $(OUTDIR)/kept-darwin-$(GOARCH).sha256

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -21,7 +21,7 @@ const (
 	stable     = "stable"
 )
 
-// options for running `meshctl check`, which checks all clusters
+// options for running `keptctl check`, which checks all clusters
 type checkOpts struct {
 	url     string
 	release string

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -103,32 +103,36 @@ func runYamlChecks(opts *checkOpts) error {
 	// Check all fields in the template exist in the current KEP
 	for key := range templateMap {
 		if _, exists := kepMap[key]; !exists {
-			fmt.Printf("Field '%s' does not exist in KEP.\n", key)
+			pterm.Printf("❌  Field '%s' does not exist in KEP.\n", key)
 		}
 	}
 
 	// Check that correct stage is set in yaml
 	if _, exists := kepMap[yamlStage]; !exists {
-		fmt.Printf("stage '%s' does not exist in KEP yaml.\n", yamlStage)
+		return fmt.Errorf("❌  stage '%s' does not exist in KEP yaml.\n", yamlStage)
 	} else {
 		if kepMap[yamlStage] != opts.stage {
-			fmt.Printf("stage '%s' is not set to '%s' in KEP yaml.\n", yamlStage, opts.stage)
+			pterm.Printf("❌  stage '%s' is not set to '%s' in KEP yaml.\n", yamlStage, opts.stage)
+		} else {
+			pterm.Printf("✅  correct stage set in KEP yaml\n")
 		}
 	}
 
 	// Check that correct release is set in yaml
 	if _, exists := kepMap[yamlMilestone]; !exists {
-		fmt.Printf("stage '%s' does not exist in KEP yaml.\n", yamlMilestone)
+		pterm.Printf("stage '%s' does not exist in KEP yaml.\n", yamlMilestone)
 	} else {
 		milestoneMap := convertToMapString(kepMap[yamlMilestone].(map[interface{}]interface{}))
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal YAML: %s", err)
+			pterm.Printf("❌  failed to unmarshal YAML: %s", err)
 		}
 		if _, stageExists := milestoneMap[opts.stage]; !stageExists {
-			return fmt.Errorf("stage '%s' does not exist in KEP yaml for milestone %s", opts.stage, milestoneMap)
+			pterm.Printf("❌  stage '%s' does not exist in KEP yaml for milestone %s\n", opts.stage, milestoneMap)
 		} else {
 			if milestoneMap[opts.stage] != opts.release {
-				fmt.Printf("release '%s' is not set to '%s' in KEP yaml.\n", milestoneMap[opts.stage], opts.release)
+				pterm.Printf("❌  release '%s' is not set to '%s' in KEP yaml.\n", milestoneMap[opts.stage], opts.release)
+			} else {
+				pterm.Printf("✅  correct milestone set in KEP yaml\n")
 			}
 		}
 	}
@@ -136,24 +140,28 @@ func runYamlChecks(opts *checkOpts) error {
 	// Check that correct status is set in yaml
 	if opts.stage == graduating || opts.stage == stable {
 		if _, exists := kepMap[yamlStatus]; !exists {
-			fmt.Printf("status '%s' does not exist in KEP yaml.\n", yamlStatus)
+			pterm.Printf("❌  status '%s' does not exist in KEP yaml.\n", yamlStatus)
 		} else {
 			if kepMap[yamlStatus] != "implemented" {
-				fmt.Printf("status '%s' is not set to '%s' in KEP yaml.\n", yamlStatus, "implemented")
+				pterm.Printf("❌  status '%s' is not set to '%s' in KEP yaml.\n", yamlStatus, "implemented")
+			} else {
+				pterm.Printf("✅  correct status set in KEP yaml\n")
 			}
 		}
 	} else {
 		// alpha/beta
 		if _, exists := kepMap[yamlStatus]; !exists {
-			fmt.Printf("status '%s' does not exist in KEP yaml.\n", yamlStatus)
+			pterm.Printf("❌  status '%s' does not exist in KEP yaml.\n", yamlStatus)
 		} else {
 			if kepMap[yamlStatus] != "implementable" {
-				fmt.Printf("status '%s' is not set to '%s' in KEP yaml.\n", yamlStatus, "implementable")
+				pterm.Printf("❌  status '%s' is not set to '%s' in KEP yaml.\n", yamlStatus, "implementable")
+			} else {
+				pterm.Printf("✅  correct status set in KEP yaml\n")
 			}
 		}
 	}
 
-	fmt.Println("KEP passed checks.")
+	pterm.Println("Finished KEP checks")
 	return nil
 }
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,211 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/pterm/pterm"
+	"github.com/salaxander/kept/pkg/check"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v2"
+	"strconv"
+)
+
+const (
+	yamlStage     = "stage"
+	yamlMilestone = "milestone"
+	yamlStatus    = "status" // `implementable`, if graduating needs to be updated to `implemented`
+
+	alpha      = "alpha"
+	beta       = "beta"
+	graduating = "graduating"
+	stable     = "stable"
+)
+
+// options for running `meshctl check`, which checks all clusters
+type checkOpts struct {
+	url     string
+	release string
+	stage   string
+}
+
+func (o *checkOpts) addToFlags(flags *pflag.FlagSet) {
+	flags.StringVar(
+		&o.url,
+		"url",
+		"",
+		"url to KEP yaml",
+	)
+	flags.StringVarP(
+		&o.release,
+		"release",
+		"r",
+		"",
+		"release version",
+	)
+	flags.StringVarP(
+		&o.stage,
+		"stage",
+		"s",
+		"",
+		"stage (alpha/beta/graduating/stable)",
+	)
+}
+
+func Command() *cobra.Command {
+	opts := &checkOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Check a KEP complies with template for a specific version",
+		Long:  `Check a KEP by providing an individual KEP yaml, the release it is targeting and the stage (alpha/beta/stable).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runYamlChecks(opts)
+		},
+	}
+
+	opts.addToFlags(cmd.Flags())
+
+	return cmd
+}
+
+func runYamlChecks(opts *checkOpts) error {
+	pterm.Println("")
+
+	err := opts.validate()
+	if err != nil {
+		return fmt.Errorf("invalid options: %w", err)
+	}
+
+	kepYaml, err := check.GetKepYaml(opts.url)
+	if err != nil {
+		return err
+	}
+
+	var kepMap map[string]interface{}
+	err = yaml.Unmarshal([]byte(kepYaml), &kepMap)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal YAML: %s", err)
+	}
+
+	// TODO: imo this should be versioned
+	urlTemplateForLatest := "https://github.com/kubernetes/enhancements/blob/master/keps/NNNN-kep-template/kep.yaml"
+	templateYaml, err := check.GetKepYaml(urlTemplateForLatest)
+	if err != nil {
+		return err
+	}
+
+	var templateMap map[string]interface{}
+	err = yaml.Unmarshal([]byte(templateYaml), &templateMap)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal YAML: %s", err)
+	}
+
+	// Check all fields in the template exist in the current KEP
+	for key := range templateMap {
+		if _, exists := kepMap[key]; !exists {
+			fmt.Printf("Field '%s' does not exist in KEP.\n", key)
+		}
+	}
+
+	// Check that correct stage is set in yaml
+	if _, exists := kepMap[yamlStage]; !exists {
+		fmt.Printf("stage '%s' does not exist in KEP yaml.\n", yamlStage)
+	} else {
+		if kepMap[yamlStage] != opts.stage {
+			fmt.Printf("stage '%s' is not set to '%s' in KEP yaml.\n", yamlStage, opts.stage)
+		}
+	}
+
+	// Check that correct release is set in yaml
+	if _, exists := kepMap[yamlMilestone]; !exists {
+		fmt.Printf("stage '%s' does not exist in KEP yaml.\n", yamlMilestone)
+	} else {
+		milestoneMap := convertToMapString(kepMap[yamlMilestone].(map[interface{}]interface{}))
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal YAML: %s", err)
+		}
+		if _, stageExists := milestoneMap[opts.stage]; !stageExists {
+			return fmt.Errorf("stage '%s' does not exist in KEP yaml for milestone %s", opts.stage, milestoneMap)
+		} else {
+			if milestoneMap[opts.stage] != opts.release {
+				fmt.Printf("release '%s' is not set to '%s' in KEP yaml.\n", milestoneMap[opts.stage], opts.release)
+			}
+		}
+	}
+
+	// Check that correct status is set in yaml
+	if opts.stage == graduating || opts.stage == stable {
+		if _, exists := kepMap[yamlStatus]; !exists {
+			fmt.Printf("status '%s' does not exist in KEP yaml.\n", yamlStatus)
+		} else {
+			if kepMap[yamlStatus] != "implemented" {
+				fmt.Printf("status '%s' is not set to '%s' in KEP yaml.\n", yamlStatus, "implemented")
+			}
+		}
+	} else {
+		// alpha/beta
+		if _, exists := kepMap[yamlStatus]; !exists {
+			fmt.Printf("status '%s' does not exist in KEP yaml.\n", yamlStatus)
+		} else {
+			if kepMap[yamlStatus] != "implementable" {
+				fmt.Printf("status '%s' is not set to '%s' in KEP yaml.\n", yamlStatus, "implementable")
+			}
+		}
+	}
+
+	fmt.Println("KEP passed checks.")
+	return nil
+}
+
+func (opts *checkOpts) validate() error {
+	if opts.stage != alpha && opts.stage != beta && opts.stage != stable && opts.stage != graduating {
+		return fmt.Errorf("Invalid stage type '%s'. Supported output types are: %s, %s, %s, %s", opts.stage, alpha, beta, stable, graduating)
+	}
+
+	if opts.release == "" {
+		return fmt.Errorf("Invalid release version '%s'", opts.release)
+	}
+
+	if opts.url == "" {
+		return fmt.Errorf("Invalid url '%s'", opts.url)
+	}
+
+	return nil
+}
+
+func init() {
+	checkCmd := Command()
+
+	rootCmd.AddCommand(checkCmd)
+}
+
+// Recursive function to convert a map[interface{}]interface{} to map[string]string
+func convertToMapString(data map[interface{}]interface{}) map[string]string {
+	strMap := make(map[string]string)
+	for key, value := range data {
+		strKey := convertToString(key)
+		strValue := convertToString(value)
+		strMap[strKey] = strValue
+	}
+	return strMap
+}
+
+// Recursive function to convert an interface value to a string
+func convertToString(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case int:
+		return strconv.Itoa(v)
+	case bool:
+		return strconv.FormatBool(v)
+	case map[interface{}]interface{}:
+		strMap := make(map[string]string)
+		for k, v := range v {
+			strMap[convertToString(k)] = convertToString(v)
+		}
+		return fmt.Sprintf("%v", strMap)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,8 +41,8 @@ var getCmd = &cobra.Command{
 		headerStyle := pterm.NewStyle(pterm.FgLightCyan, pterm.Bold)
 		pterm.DefaultSection.WithStyle(headerStyle).WithIndentCharacter("\u2638\ufe0f ").Printfln("KEP %s", k.IssueNumber)
 		pterm.Printfln("Title: %s", k.Title)
-		if k.Milstone != "" {
-			pterm.Printfln("Milestone: %s", k.Milstone)
+		if k.Milestone != "" {
+			pterm.Printfln("Milestone: %s", k.Milestone)
 		}
 		if k.SIG != "" {
 			pterm.Println("SIG: %s", k.SIG)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pterm/pterm v0.12.27
 	github.com/spf13/cobra v1.2.1
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -1,0 +1,52 @@
+package check
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+func GetKepYaml(url string) (string, error) {
+	// Convert the GitHub URL to the raw URL format
+	rawURL := convertToRawURL(url)
+
+	// Fetch the raw content of the code file
+	content, err := fetchRawContent(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("Failed to fetch raw content: %s\n", err)
+	}
+
+	return content, nil
+}
+
+// Convert a GitHub URL to its raw URL format
+func convertToRawURL(url string) string {
+	// Replace the 'github.com' domain with 'raw.githubusercontent.com'
+	rawURL := strings.Replace(url, "github.com", "raw.githubusercontent.com", 1)
+
+	// Remove the '/blob' segment from the URL path
+	rawURL = strings.Replace(rawURL, "/blob", "", 1)
+
+	return rawURL
+}
+
+// Fetch the raw content of a given URL
+func fetchRawContent(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("request failed with status code %d", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}

--- a/pkg/kep/kep.go
+++ b/pkg/kep/kep.go
@@ -23,7 +23,7 @@ func init() {
 
 type KEP struct {
 	IssueNumber string
-	Milstone    string
+	Milestone   string
 	SIG         string
 	Stage       string
 	Title       string
@@ -78,7 +78,7 @@ func issueToKEP(issue *github.Issue) *KEP {
 		URL:         *issue.HTMLURL,
 	}
 	if issue.Milestone != nil {
-		kep.Milstone = *issue.Milestone.Title
+		kep.Milestone = *issue.Milestone.Title
 	}
 	for i := range issue.Labels {
 		if strings.Contains(*issue.Labels[i].Name, "sig") {


### PR DESCRIPTION
Mark shared this repo during the last release and I like the idea of automating some of the KEP checks the enhancement team has to do to validate an enhancement. This just adds a `kept check` command that validates the yaml in a provided KEY vs the template on main. Let me know what you think @salaxander ! 

Failed check example:

```
❯ _output/kept-darwin-amd64 check -r v1.23 -s alpha  --url  https://raw.githubusercontent.com/kubernetes/enhancements/master/keps/sig-storage/3333-reconcile-default-storage-class/kep.yaml

❌  stage 'stage' is not set to 'alpha' in KEP yaml.
❌  release 'v1.25' is not set to 'v1.23' in KEP yaml.
✅  correct status set in KEP yaml
Finished KEP checks

```

Success check example:

```
❯ _output/kept-darwin-amd64 check -r v1.26 -s beta --url  https://raw.githubusercontent.com/kubernetes/enhancements/master/keps/sig-storage/3333-reconcile-default-storage-class/kep.yaml  

✅  correct stage set in KEP yaml
✅  correct milestone set in KEP yaml
✅  correct status set in KEP yaml
Finished KEP checks

```